### PR TITLE
User `RuntimeerrorNotifier` module

### DIFF
--- a/lib/generators/runtimeerror_notifier/install_generator.rb
+++ b/lib/generators/runtimeerror_notifier/install_generator.rb
@@ -1,8 +1,10 @@
-class RuntimeerrorNotifier::InstallGenerator < Rails::Generators::Base
-  source_root File.expand_path('../templates', __FILE__)
-  desc 'Creates an initializer file for RuntimeError.net at config/initializers'
+module RuntimeerrorNotifier
+  class InstallGenerator < Rails::Generators::Base
+    source_root File.expand_path('../templates', __FILE__)
+    desc 'Creates an initializer file for RuntimeError.net at config/initializers'
 
-  def install
-    template 'initializer.rb', 'config/initializers/runtimeerror_notifier.rb'
+    def install
+      template 'initializer.rb', 'config/initializers/runtimeerror_notifier.rb'
+    end
   end
 end


### PR DESCRIPTION
Before the fix, I am getting this error:

```
$ rails g runtimeerror_notifier:install                                                                                                                       [ruby-2.1.5]
[WARNING] Could not load generator "generators/runtimeerror_notifier/install_generator". Error: uninitialized constant RuntimeerrorNotifier.
/project/vendor/bundle/ruby/2.1.0/gems/runtimeerror_notifier-0.0.23/lib/generators/runtimeerror_notifier/install_generator.rb:1:in `<top (required)>'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:281:in `block (2 levels) in lookup'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:277:in `each'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:277:in `block in lookup'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:276:in `each'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:276:in `lookup'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:138:in `find_by_namespace'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:155:in `invoke'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/commands/generate.rb:11:in `<top (required)>'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:135:in `generate_or_destroy'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:51:in `generate'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
/project/vendor/bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/commands.rb:17:in `<top (required)>'
/project/bin/rails:8:in `<top (required)>'
/Users/winston/.rvm/rubies/ruby-2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/Users/winston/.rvm/rubies/ruby-2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
-e:1:in `<main>'
Could not find generator runtimeerror_notifier:install.
```
